### PR TITLE
Fix broken links in naming.md

### DIFF
--- a/naming.md
+++ b/naming.md
@@ -20,7 +20,7 @@ There should be no reason to not follow at least these :\)
 3. Always use singular nouns for names.
 4. Use `-` inside arguments values and in places where value will be exposed to a human \(eg, inside DNS name of RDS instance\).
 5. Include `count` argument inside resource blocks as the first argument at the top and separate by newline after it. See [example](naming.md#usage-of-count).
-6. Include `tags` argument, if supported by resource as the last real argument, following by `depends_on` and `lifecycle`, if necessary. All of these should be separated by single empty line. See [example](naming.md#usage-of-tags).
+6. Include `tags` argument, if supported by resource as the last real argument, following by `depends_on` and `lifecycle`, if necessary. All of these should be separated by single empty line. See [example](naming.md#placement-of-tags).
 7. When using condition in `count` argument use boolean value, if it makes sense, otherwise use `length` or other interpolation. See [example](naming.md#conditions-in-count).
 8. To make inverted conditions don't introduce another variable unless really necessary, use `1 - boolean value` instead. For example, `count = "${1 - var.create_public_subnets}"`
 
@@ -147,7 +147,7 @@ Name for the outputs is important to make them consistent and understandable out
    3. `{attribute}` is an attribute returned by the output
    4. [See examples](naming.md#code-examples-of-output).
 3. If output is returning a value with interpolation functions and multiple resources, the `{name}` and `{type}` there should be as generic as possible \(`this` is often the most generic and should be preferred\). [See example](naming.md#code-examples-of-output).
-4. If the returned value is a list it should have plural name. [See example](naming.md#use-plural-name-if-returning-value-is-type-of-list).
+4. If the returned value is a list it should have plural name. [See example](naming.md#use-plural-name-if-the-returning-value-is-a-list).
 5. Always include `description` for all outputs even if you think it is obvious.
 
 ### Code examples of `output`


### PR DESCRIPTION
Fixed broken links in `naming.md`.

This can be fixed in two ways, but "fix links" is applied here:
- fix links
  - ex) `[example](naming.md#usage-of-tags)` => `[example](naming.md#placement-of-tags)` 
- fix targets of links
  - `### Placement of tags` => `### Usage of tags`