### PR TITLE
doc: split ternary operators

### DIFF
--- a/writing-terraform-configurations.md
+++ b/writing-terraform-configurations.md
@@ -6,6 +6,30 @@ Helpful way to give a hint to Terraform that some resources should be deleted be
 
 [https://raw.githubusercontent.com/antonbabenko/terraform-best-practices/master/snippets/locals.tf](https://raw.githubusercontent.com/antonbabenko/terraform-best-practices/master/snippets/locals.tf)
 
+## Use only one ternary operator in a single variable assignment.
+
+Terraform ternary operator `count = var.enable ? 1 : 0` has been inherited from other programming languages. Its goal in programming languages is to avoid multi-line if/else statements for a simple if/else condition. It Terraform we don't have a multi-line alternative for the ternary operator
+
+Split your complex conditions into multiple `locals` with a reasonable name instead of using a long ternary operator nesting for reliability.
+
+```hcl
+# Hard to read and maintain
+locals {
+  container_definitions = var.add_logging ? concat(container_definitions, var.use_fluentbit ? local.inhouse_logging_sidecar : local.fluentbit_sidecar) : var.container_definitions
+}
+
+# Easier to read and maintain
+locals {
+  logging_container     = var.use_fluentbit ? local.inhouse_logging_sidecar : local.fluentbit_sidecar
+  container_definitions = var.add_logging ? concat(container_definitions, logging_container, ) : var.container_definitions
+}
+
+resource "aws_ecs_task_definition" "this" {
+  container_definitions = local.container_definitions
+  // ... other attributes
+}
+```
+
 ## Terraform 0.12 - Required vs Optional arguments
 
 1. Required argument `index_document` must be set, if `var.website` is not an empty map.


### PR DESCRIPTION
A practice to split long nested ternary operators into multiple locals for readability.
To avoid the same hell problem inherited from JavaScript. 