### PR TITLE
feat: update terraform experts reference and add recommendation for secrets management

### DIFF
--- a/references.md
+++ b/references.md
@@ -4,13 +4,11 @@
 There are a lot of people who create great content and manage open-source projects relevant to the Terraform community but I can't think of the best structure to get these links listed here without copying lists like [awesome-terraform](https://github.com/shuaibiyy/awesome-terraform).
 {% endhint %}
 
-[https://twitter.com/antonbabenko/lists/terraform-experts](https://twitter.com/antonbabenko/lists/terraform-experts) - List of people who work with Terraform very actively and can tell you a lot (if you ask them).
+[https://www.hashicorp.com/ambassador/directory?products=Terraform](https://www.hashicorp.com/ambassador/directory?products=Terraform) - List of people who work with Terraform very actively and can tell you a lot (if you ask them).
 
 [https://github.com/shuaibiyy/awesome-terraform](https://github.com/shuaibiyy/awesome-terraform) - Curated list of resources on HashiCorp's Terraform.
 
 [http://bit.ly/terraform-youtube](http://bit.ly/terraform-youtube) - "Your Weekly Dose of Terraform" YouTube channel by Anton Babenko. Live streams with reviews, interviews, Q\&A, live coding, and some hacking with Terraform.
 
 [https://weekly.tf](https://weekly.tf) - Terraform Weekly newsletter. Various news in the Terraform world (projects, announcements, discussions) by Anton Babenko.
-
-
 

--- a/writing-terraform-configurations.md
+++ b/writing-terraform-configurations.md
@@ -43,7 +43,7 @@ website = {
 
 ## Managing Secrets in Terraform
 
-Secrets are sensitive data that can be anything from passwords and encryption keys to API tokens and service certificates. They are typically used to set up authentication and authorization for cloud resources. Safeguarding these sensitive resources is crucial because exposure could lead to security breaches. It’s highly recommended to avoid storing secrets in Terraform config and state, as anyone with access to version control can access them. Instead, consider using external data sources to fetch secrets from external sources at runtime. For instance, if you’re using AWS Secrets Manager, you can use the `aws_secretsmanager_secret` data source to access the secret value.
+Secrets are sensitive data that can be anything from passwords and encryption keys to API tokens and service certificates. They are typically used to set up authentication and authorization for cloud resources. Safeguarding these sensitive resources is crucial because exposure could lead to security breaches. It’s highly recommended to avoid storing secrets in Terraform config and state, as anyone with access to version control can access them. Instead, consider using external data sources to fetch secrets from external sources at runtime. For instance, if you’re using AWS Secrets Manager, you can use the `aws_secretsmanager_secret_version` data source to access the secret value.
 
 {% code title="main.tf" %}
 ```hcl

--- a/writing-terraform-configurations.md
+++ b/writing-terraform-configurations.md
@@ -43,28 +43,30 @@ website = {
 
 ## Managing Secrets in Terraform
 
-Secrets are sensitive data that can be anything from passwords and encryption keys to API tokens and service certificates. They are typically used to set up authentication and authorization for cloud resources. Safeguarding these sensitive resources is crucial because exposure could lead to security breaches. It’s highly recommended to avoid storing secrets in Terraform config and state, as anyone with access to version control can access them. Instead, consider using external data sources to fetch secrets from external sources at runtime. For instance, if you’re using AWS Secrets Manager, you can use the `aws_secretsmanager_secret_version` data source to access the secret value.
+Secrets are sensitive data that can be anything from passwords and encryption keys to API tokens and service certificates. They are typically used to set up authentication and authorization for cloud resources. Safeguarding these sensitive resources is crucial because exposure could lead to security breaches. It’s highly recommended to avoid storing secrets in Terraform config and state, as anyone with access to version control can access them. Instead, consider using external data sources to fetch secrets from external sources at runtime. For instance, if you’re using AWS Secrets Manager, you can use the `aws_secretsmanager_secret_version` data source to access the secret value. The following example uses write-only arguments, which are supported in Terraform 1.11+, and keep the value out of Terraform state.
+
 
 {% code title="main.tf" %}
 ```hcl
-# Fetch the secret metadata
+# Fetch the secret’s metadata
 data "aws_secretsmanager_secret" "db_password" {
   name = "my-database-password"
 }
 
-# Fetch the latest secret value
+# Get the latest secret value
 data "aws_secretsmanager_secret_version" "db_password" {
   secret_id = data.aws_secretsmanager_secret.db_password.id
 }
 
-# Use the secret in a resource
+# Use the secret without persisting it to state
 resource "aws_db_instance" "example" {
   engine         = "mysql"
   instance_class = "db.t3.micro"
   name           = "exampledb"
   username       = "admin"
-  password       = data.aws_secretsmanager_secret_version.db_password.secret_string
-}
+
+  # write-only: Terraform sends it to AWS then forgets it
+  password_wo = data.aws_secretsmanager_secret_version.db_password.secret_string
 ```
 {% endcode %}
 

--- a/writing-terraform-configurations.md
+++ b/writing-terraform-configurations.md
@@ -43,7 +43,7 @@ website = {
 
 ## Managing Secrets in Terraform
 
-Secrets are sensitive data that can be anything from system passwords and encryption keys to APIs and service certificates. They are typically used to set up authentication and authorization for cloud resources. Safeguarding these sensitive resources is crucial because exposure could lead to security breaches. It’s highly recommended to avoid storing secrets in Terraform config and state, as anyone with access to version control can access them. Instead, consider using external data sources to fetch secrets from external sources at runtime. For instance, if you’re using AWS Secrets Manager, you can use the `aws_secretsmanager_secret` data source to access the secret value.
+Secrets are sensitive data that can be anything from passwords and encryption keys to API tokens and service certificates. They are typically used to set up authentication and authorization for cloud resources. Safeguarding these sensitive resources is crucial because exposure could lead to security breaches. It’s highly recommended to avoid storing secrets in Terraform config and state, as anyone with access to version control can access them. Instead, consider using external data sources to fetch secrets from external sources at runtime. For instance, if you’re using AWS Secrets Manager, you can use the `aws_secretsmanager_secret` data source to access the secret value.
 
 {% code title="main.tf" %}
 ```hcl

--- a/writing-terraform-configurations.md
+++ b/writing-terraform-configurations.md
@@ -40,3 +40,31 @@ website = {
 }
 ```
 {% endcode %}
+
+## Managing Secrets in Terraform
+
+Secrets are sensitive data that can be anything from system passwords and encryption keys to APIs and service certificates. They are typically used to set up authentication and authorization for cloud resources. Safeguarding these sensitive resources is crucial because exposure could lead to security breaches. It’s highly recommended to avoid storing secrets in Terraform config and state, as anyone with access to version control can access them. Instead, consider using external data sources to fetch secrets from external sources at runtime. For instance, if you’re using AWS Secrets Manager, you can use the `aws_secretsmanager_secret` data source to access the secret value.
+
+{% code title="main.tf" %}
+```hcl
+# Fetch the secret metadata
+data "aws_secretsmanager_secret" "db_password" {
+  name = "my-database-password"
+}
+
+# Fetch the latest secret value
+data "aws_secretsmanager_secret_version" "db_password" {
+  secret_id = data.aws_secretsmanager_secret.db_password.id
+}
+
+# Use the secret in a resource
+resource "aws_db_instance" "example" {
+  engine         = "mysql"
+  instance_class = "db.t3.micro"
+  name           = "exampledb"
+  username       = "admin"
+  password       = data.aws_secretsmanager_secret_version.db_password.secret_string
+}
+```
+{% endcode %}
+


### PR DESCRIPTION
## What and Why

- The [Twitter Terraform Experts Link](https://twitter.com/antonbabenko/lists/terraform-experts) no longer exists. How do you feel about updating this to the Hashicorp ambassador list? Or is there another location for the list you created @antonbabenko ?
- I also noticed a TODO item to add a recommendation for managing secrets in Terraform. While there are far more comprehensive guides available, I’ve included a concise explanation of managing secrets in Terraform with an explanation demonstrating how to use external data sources (with an example of fetching a database password using AWS Secrets Manager).