### PR TITLE
docs: add additional guidance on remote state and formatting

### DIFF
--- a/code-styling.md
+++ b/code-styling.md
@@ -7,6 +7,23 @@
 * Use [Terraform pre-commit hooks](https://github.com/antonbabenko/pre-commit-terraform) to make sure that the code is valid, properly formatted, and automatically documented before it is pushed to git and reviewed by humans.
 {% endhint %}
 
+## Formatting
+
+Terraform’s `terraform fmt` command enforces the canonical style for configuration files. The tool is intentionally opinionated and non-configurable, guaranteeing a uniform format across codebases so reviewers can focus on substance rather than style. Integrate it with [Terraform pre-commit hooks](https://github.com/antonbabenko/pre-commit-terraform) to validate and format code automatically before it reaches version control.
+
+For example:
+
+```yaml
+# .pre-commit-config.yaml
+repos:
+  - repo: https://github.com/antonbabenko/pre-commit-terraform
+    rev: v1.97.0
+    hooks:
+      - id: terraform_fmt
+```
+
+In CI pipelines, use `terraform fmt -check` to verify compliance. It exits with status 0 when all files are correctly formatted; otherwise, it returns a non-zero code and lists the offending files. Centralizing formatting in this way removes merge friction and enforces a consistent standard across teams.
+
 ## Editor Configuration
 
 - **Use `.editorconfig`**: [EditorConfig](https://editorconfig.org/) helps maintain consistent coding styles for multiple developers working on the same project across various editors and IDEs. Include an `.editorconfig` file in your repositories to maintain consistent whitespace and indentation.

--- a/key-concepts.md
+++ b/key-concepts.md
@@ -40,7 +40,7 @@ The [http](https://registry.terraform.io/providers/hashicorp/http/latest/docs/da
 
 ## Remote state
 
-Infrastructure modules and compositions should persist their [Terraform state](https://www.terraform.io/docs/language/state/index.html) in a remote location where it can be retrieved by others in a controllable way (e.g., specify ACL, versioning, logging).
+Store [Terraform state](https://www.terraform.io/docs/language/state/index.html) for each infrastructure module and composition in a remote backend, configured with ACLs, versioning, and logging. This single, authoritative source of truth keeps environments consistent and typically includes disaster-recovery features such as automated backups. Managing state locally can lead to collaboration issues and race conditions when multiple developers run Terraform at the same time, resulting in unpredictable outcomes.
 
 ## Provider, provisioner, etc
 


### PR DESCRIPTION
## Why

- I am a huge fan of this resource, and my goal is to iterate on best practices as Terraform continues to grow and introduce new features.

## What

- [X] Update the Remote State guidance to include reasons for why local state management falls short
- [X] Introduce a section on formatting and how to integrate it into local development and validate in CI pipelines